### PR TITLE
Add createPortal support for rendering into external DOM nodes

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -360,7 +360,7 @@ instantiate(element) // → shadowRoot
 | Fiber Architecture | Yes | No (simpler recursion) |
 | DevTools | Yes | No |
 | Error Boundaries | Yes | No |
-| Portals | Yes | No (use Shadow DOM) |
+| Portals | Yes | Yes |
 | Strict Mode | Yes | Basic |
 
 ### When to Use iRact

--- a/dist/iract.d.ts
+++ b/dist/iract.d.ts
@@ -52,6 +52,9 @@ export function cloneElement<P>(
 
 export function isValidElement(object: any): object is IRactElement;
 
+// Portals
+export function createPortal(children: IRactNode, container: Element): IRactElement;
+
 // Context
 export function createContext<T>(defaultValue: T): Context<T>;
 
@@ -143,6 +146,7 @@ declare const iRact: {
     unmount: typeof unmount;
     cloneElement: typeof cloneElement;
     isValidElement: typeof isValidElement;
+    createPortal: typeof createPortal;
     version: string;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iract",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A lightweight React-like framework with hooks, context, and virtual DOM",
   "author": "hriks",
   "license": "MIT",

--- a/src/iract.js
+++ b/src/iract.js
@@ -10,6 +10,7 @@
 // --- Internal Symbols ---
 const IRACT_ELEMENT = Symbol.for("iract.element");
 const IRACT_FRAGMENT = Symbol.for("iract.fragment");
+const IRACT_PORTAL = Symbol.for("iract.portal");
 
 // --- Namespaces for SVG ---
 const SVG_NS = "http://www.w3.org/2000/svg";
@@ -98,6 +99,17 @@ function cloneElement(element, props, ...children) {
 
 function isValidElement(object) {
     return typeof object === "object" && object !== null && object.$typeof === IRACT_ELEMENT;
+}
+
+function createPortal(children, container) {
+    if (!container || typeof container.appendChild !== "function") {
+        throw new Error("iRact.createPortal: container must be a DOM element");
+    }
+    return {
+        $typeof: IRACT_ELEMENT,
+        type: IRACT_PORTAL,
+        props: { children: Array.isArray(children) ? children : [children], container }
+    };
 }
 
 // ---------- Context ----------
@@ -219,6 +231,19 @@ function unmountInstance(instance) {
 function removeInstance(parent, instance) {
     if (!instance) return;
     unmountInstance(instance); // run cleanups
+    if (instance._portalContainer) {
+        // Portal: remove children from the portal container
+        const pc = instance._portalContainer;
+        (instance.childInstances || []).forEach(ci => {
+            if (ci && ci.dom && ci.dom.parentNode === pc) pc.removeChild(ci.dom);
+            if (ci && ci._range) removeRange(pc, ci._range.start, ci._range.end);
+        });
+        // Remove placeholder comment from parent
+        if (instance.dom && instance.dom.parentNode === parent) {
+            parent.removeChild(instance.dom);
+        }
+        return;
+    }
     if (instance._range) {
         removeRange(parent, instance._range.start, instance._range.end);
     } else if (instance.dom && instance.dom.parentNode === parent) {
@@ -424,6 +449,34 @@ function reconcile(parentDom, instance, element) {
         return instance;
     }
 
+    if (element.type === IRACT_PORTAL) {
+        const oldContainer = instance._portalContainer;
+        const newContainer = element.props.container;
+        const nextEls = normalizeChildren(element.props.children);
+        const oldChildren = instance.childInstances || [];
+
+        if (oldContainer === newContainer) {
+            // Same container — reconcile children in place
+            instance.childInstances = reconcileList(newContainer, oldChildren, nextEls, null);
+        } else {
+            // Container changed — remove from old, re-instantiate in new
+            oldChildren.forEach(ci => removeInstance(oldContainer, ci));
+            const newChildren = nextEls.map(el => instantiate(el, "html")).filter(Boolean);
+            newChildren.forEach(ci => {
+                if (ci._mountNodes && ci._range) {
+                    mountRange(newContainer, ci._range.start, ci._range.end, ci._mountNodes);
+                    delete ci._mountNodes;
+                } else if (ci.dom) {
+                    newContainer.appendChild(ci.dom);
+                }
+            });
+            instance.childInstances = newChildren;
+            instance._portalContainer = newContainer;
+        }
+        instance.element = element;
+        return instance;
+    }
+
     console.error("iRact.reconcile: invalid element", element);
     return null;
 }
@@ -506,6 +559,23 @@ function instantiate(element, ns = "html") {
             }
         });
         return { element, childInstances, _range: range, _mountNodes: mountNodes };
+    }
+
+    if (element.type === IRACT_PORTAL) {
+        const portalContainer = element.props.container;
+        const children = normalizeChildren(element.props.children);
+        const childInstances = children.map(el => instantiate(el, "html")).filter(Boolean);
+        childInstances.forEach(ci => {
+            if (ci._mountNodes && ci._range) {
+                mountRange(portalContainer, ci._range.start, ci._range.end, ci._mountNodes);
+                delete ci._mountNodes;
+            } else if (ci.dom) {
+                portalContainer.appendChild(ci.dom);
+            }
+        });
+        // Placeholder comment in the parent DOM for position tracking
+        const placeholder = document.createComment("iract:portal");
+        return { dom: placeholder, element, childInstances, _portalContainer: portalContainer };
     }
 
     if (typeof element.type === "function") {
@@ -854,8 +924,8 @@ const iRact = {
     useState, useEffect, useMemo, useCallback, useContext, createContext, useReducer, useRef,
     memo, forwardRef, lazy, Suspense, StrictMode, Profiler,
     render, renderLegacy, unmount,
-    cloneElement, isValidElement,
-    version: "0.0.5"
+    cloneElement, isValidElement, createPortal,
+    version: "0.0.7"
 };
 
 export default iRact;
@@ -866,6 +936,7 @@ export {
     h,
     cloneElement,
     isValidElement,
+    createPortal,
     createContext,
     render,
     renderLegacy,

--- a/tests/portal.test.js
+++ b/tests/portal.test.js
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import iRact, { render, createElement, createPortal, useState, useEffect, useContext, createContext } from '../src/iract.js';
+
+const h = createElement;
+const Fragment = iRact.Fragment;
+
+describe('createPortal', () => {
+    let container;
+    let portalTarget;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        portalTarget = document.createElement('div');
+        document.body.appendChild(container);
+        document.body.appendChild(portalTarget);
+    });
+
+    it('renders children into the portal target, not the parent', () => {
+        function App() {
+            return h('div', null,
+                h('span', null, 'parent content'),
+                createPortal(h('p', null, 'portal content'), portalTarget)
+            );
+        }
+        render(App, null, container);
+        expect(container.textContent).toBe('parent content');
+        expect(portalTarget.querySelector('p').textContent).toBe('portal content');
+    });
+
+    it('places a placeholder comment in the parent DOM', () => {
+        function App() {
+            return h('div', null,
+                createPortal(h('span', null, 'hello'), portalTarget)
+            );
+        }
+        render(App, null, container);
+        const div = container.querySelector('div');
+        const comments = [];
+        for (const node of div.childNodes) {
+            if (node.nodeType === Node.COMMENT_NODE) comments.push(node);
+        }
+        expect(comments.some(c => c.nodeValue === 'iract:portal')).toBe(true);
+    });
+
+    it('supports state updates inside portal children', async () => {
+        let setter;
+        function Counter() {
+            const [count, setCount] = useState(0);
+            setter = setCount;
+            return h('span', null, `count:${count}`);
+        }
+        function App() {
+            return h('div', null,
+                createPortal(h(Counter, null), portalTarget)
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.textContent).toBe('count:0');
+
+        setter(1);
+        await new Promise(r => queueMicrotask(r));
+        expect(portalTarget.textContent).toBe('count:1');
+    });
+
+    it('runs useEffect in portal children', () => {
+        const effectFn = vi.fn();
+        function Child() {
+            useEffect(effectFn, []);
+            return h('div', null, 'effect child');
+        }
+        function App() {
+            return createPortal(h(Child, null), portalTarget);
+        }
+        render(App, null, container);
+        expect(effectFn).toHaveBeenCalledTimes(1);
+        expect(portalTarget.textContent).toBe('effect child');
+    });
+
+    it('cleans up portal children when portal is removed', async () => {
+        let toggle;
+        const cleanupFn = vi.fn();
+        function PortalChild() {
+            useEffect(() => cleanupFn, []);
+            return h('span', null, 'portal child');
+        }
+        function App() {
+            const [show, setShow] = useState(true);
+            toggle = setShow;
+            return h('div', null,
+                show ? createPortal(h(PortalChild, null), portalTarget) : null
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.textContent).toBe('portal child');
+
+        toggle(false);
+        await new Promise(r => queueMicrotask(r));
+        expect(portalTarget.textContent).toBe('');
+        expect(cleanupFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates context through portal', () => {
+        const ThemeCtx = createContext('light');
+        function PortalChild() {
+            const theme = useContext(ThemeCtx);
+            return h('span', null, `theme:${theme}`);
+        }
+        function App() {
+            return h(ThemeCtx.Provider, { value: 'dark' },
+                h('div', null,
+                    createPortal(h(PortalChild, null), portalTarget)
+                )
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.textContent).toBe('theme:dark');
+    });
+
+    it('handles portal container change', async () => {
+        const target1 = document.createElement('div');
+        const target2 = document.createElement('div');
+        document.body.appendChild(target1);
+        document.body.appendChild(target2);
+
+        let setTarget;
+        function App() {
+            const [target, _setTarget] = useState(target1);
+            setTarget = _setTarget;
+            return h('div', null,
+                createPortal(h('p', null, 'moved'), target)
+            );
+        }
+        render(App, null, container);
+        expect(target1.querySelector('p').textContent).toBe('moved');
+        expect(target2.querySelector('p')).toBeNull();
+
+        setTarget(target2);
+        await new Promise(r => queueMicrotask(r));
+        expect(target1.querySelector('p')).toBeNull();
+        expect(target2.querySelector('p').textContent).toBe('moved');
+    });
+
+    it('supports nested portals', () => {
+        const inner = document.createElement('div');
+        document.body.appendChild(inner);
+
+        function App() {
+            return h('div', null,
+                createPortal(
+                    h('div', null,
+                        'outer portal',
+                        createPortal(h('span', null, 'inner portal'), inner)
+                    ),
+                    portalTarget
+                )
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.textContent).toBe('outer portal');
+        expect(inner.textContent).toBe('inner portal');
+    });
+
+    it('supports fragment children in portal', () => {
+        function App() {
+            return h('div', null,
+                createPortal(
+                    h(Fragment, null,
+                        h('span', null, 'a'),
+                        h('span', null, 'b')
+                    ),
+                    portalTarget
+                )
+            );
+        }
+        render(App, null, container);
+        const spans = portalTarget.querySelectorAll('span');
+        expect(spans.length).toBe(2);
+        expect(spans[0].textContent).toBe('a');
+        expect(spans[1].textContent).toBe('b');
+    });
+
+    it('throws on invalid container', () => {
+        expect(() => createPortal(h('div', null), null)).toThrow('container must be a DOM element');
+        expect(() => createPortal(h('div', null), 'not-a-dom')).toThrow('container must be a DOM element');
+        expect(() => createPortal(h('div', null), {})).toThrow('container must be a DOM element');
+    });
+
+    it('renders multiple children in portal', () => {
+        function App() {
+            return h('div', null,
+                createPortal(
+                    [h('span', null, 'first'), h('span', null, 'second')],
+                    portalTarget
+                )
+            );
+        }
+        render(App, null, container);
+        const spans = portalTarget.querySelectorAll('span');
+        expect(spans.length).toBe(2);
+        expect(spans[0].textContent).toBe('first');
+        expect(spans[1].textContent).toBe('second');
+    });
+});


### PR DESCRIPTION
Implements portals for modals, tooltips, and dropdowns that need to escape overflow/z-index contexts. Children render into a target container while staying in the virtual component tree for context and state.

Bumps version to 0.0.7.