### PR TITLE
Fix portal cleanup bugs, add h type export, and bump version to 0.0.9

### DIFF
--- a/dist/iract.d.ts
+++ b/dist/iract.d.ts
@@ -52,6 +52,8 @@ export function cloneElement<P>(
 
 export function isValidElement(object: any): object is IRactElement;
 
+export { createElement as h };
+
 // Portals
 export function createPortal(children: IRactNode, container: Element): IRactElement;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iract",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A lightweight React-like framework with hooks, context, and virtual DOM",
   "author": "hriks",
   "license": "MIT",

--- a/src/iract.js
+++ b/src/iract.js
@@ -185,6 +185,7 @@ function render(component, props, container, options = {}) {
         shadowRoot,
         instance,
         unmount: () => {
+            unmountInstance(container._iractRoot?.instance);
             if (shadowRoot) {
                 shadowRoot.innerHTML = "";
                 delete container._iractShadowRoot;
@@ -219,6 +220,18 @@ function unmountInstance(instance) {
     if (instance.childInstances) instance.childInstances.forEach(unmountInstance);
     if (instance.childInstance) unmountInstance(instance.childInstance);
 
+    // Portal: remove children from the portal container on unmount
+    if (instance._portalContainer) {
+        const pc = instance._portalContainer;
+        (instance.childInstances || []).forEach(ci => {
+            if (ci && ci._range) {
+                removeRange(pc, ci._range.start, ci._range.end);
+            } else if (ci && ci.dom && ci.dom.parentNode === pc) {
+                pc.removeChild(ci.dom);
+            }
+        });
+    }
+
     if (instance.hooks) {
         for (const h of instance.hooks) {
             if (h && typeof h.cleanup === "function") {
@@ -232,13 +245,8 @@ function removeInstance(parent, instance) {
     if (!instance) return;
     unmountInstance(instance); // run cleanups
     if (instance._portalContainer) {
-        // Portal: remove children from the portal container
-        const pc = instance._portalContainer;
-        (instance.childInstances || []).forEach(ci => {
-            if (ci && ci.dom && ci.dom.parentNode === pc) pc.removeChild(ci.dom);
-            if (ci && ci._range) removeRange(pc, ci._range.start, ci._range.end);
-        });
-        // Remove placeholder comment from parent
+        // Portal children already cleaned from container by unmountInstance above.
+        // Just remove the placeholder comment from the parent.
         if (instance.dom && instance.dom.parentNode === parent) {
             parent.removeChild(instance.dom);
         }
@@ -925,7 +933,7 @@ const iRact = {
     memo, forwardRef, lazy, Suspense, StrictMode, Profiler,
     render, renderLegacy, unmount,
     cloneElement, isValidElement, createPortal,
-    version: "0.0.8"
+    version: "0.0.9"
 };
 
 export default iRact;

--- a/tests/portal.test.js
+++ b/tests/portal.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import iRact, { render, createElement, createPortal, useState, useEffect, useContext, createContext } from '../src/iract.js';
+import iRact, { render, unmount, createElement, createPortal, useState, useEffect, useContext, createContext } from '../src/iract.js';
 
 const h = createElement;
 const Fragment = iRact.Fragment;
@@ -183,6 +183,38 @@ describe('createPortal', () => {
         expect(() => createPortal(h('div', null), null)).toThrow('container must be a DOM element');
         expect(() => createPortal(h('div', null), 'not-a-dom')).toThrow('container must be a DOM element');
         expect(() => createPortal(h('div', null), {})).toThrow('container must be a DOM element');
+    });
+
+    it('cleans up portal children from target on unmount', () => {
+        function App() {
+            return h('div', null,
+                createPortal(h('p', null, 'portal content'), portalTarget)
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.querySelector('p').textContent).toBe('portal content');
+
+        unmount(container);
+        expect(portalTarget.querySelector('p')).toBeNull();
+    });
+
+    it('cleans up fragment-returning component in portal on unmount', () => {
+        function FragList() {
+            return h(Fragment, null,
+                h('span', null, 'x'),
+                h('span', null, 'y')
+            );
+        }
+        function App() {
+            return h('div', null,
+                createPortal(h(FragList, null), portalTarget)
+            );
+        }
+        render(App, null, container);
+        expect(portalTarget.querySelectorAll('span').length).toBe(2);
+
+        unmount(container);
+        expect(portalTarget.querySelectorAll('span').length).toBe(0);
     });
 
     it('renders multiple children in portal', () => {


### PR DESCRIPTION
- Fix unmount() not running cleanup hooks or removing portal children
- Fix stale instance capture in unmount closure
- Fix fragment-returning components not fully cleaned from portal container
- Remove duplicate portal cleanup code in removeInstance
- Add missing TypeScript export for h (createElement alias)
- Add tests for portal unmount and fragment cleanup